### PR TITLE
Move --no-color to base command

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -18,7 +18,6 @@ import pytest
 
 from twine import commands
 from twine import package as package_file
-from twine import settings
 from twine.commands import check
 
 
@@ -159,8 +158,8 @@ def test_check_failing_distribution(monkeypatch):
 
 def test_main(monkeypatch):
     check_result = pretend.stub()
-    check_stub = pretend.call_recorder(lambda a, check_settings: check_result)
+    check_stub = pretend.call_recorder(lambda a: check_result)
     monkeypatch.setattr(check, "check", check_stub)
 
     assert check.main(["dist/*"]) == check_result
-    assert check_stub.calls[0].args[0] == ["dist/*"]
+    assert check_stub.calls == [pretend.call(["dist/*"])]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,24 +13,17 @@
 import sys
 
 import colorama
-import pretend
 
 from twine import __main__ as dunder_main
-from twine import cli
-from twine import exceptions
 
 
 def test_exception_handling(monkeypatch):
-    replaced_dispatch = pretend.raiser(exceptions.InvalidConfiguration("foo"))
-    monkeypatch.setattr(cli, "dispatch", replaced_dispatch)
-    assert (
-        dunder_main.main()
-        == colorama.Fore.RED + "InvalidConfiguration: foo" + colorama.Style.RESET_ALL
-    )
+    monkeypatch.setattr(sys, "argv", ["twine", "upload", "missing.whl"])
+    message = "InvalidDistribution: Cannot find file (or expand pattern): 'missing.whl'"
+    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
 
 
 def test_no_color_exception(monkeypatch):
-    replaced_dispatch = pretend.raiser(exceptions.InvalidConfiguration("foo"))
-    monkeypatch.setattr(cli, "dispatch", replaced_dispatch)
-    monkeypatch.setattr(sys, "argv", ["upload", "--no-color"])
-    assert dunder_main.main() == "InvalidConfiguration: foo"
+    monkeypatch.setattr(sys, "argv", ["twine", "--no-color", "upload", "missing.whl"])
+    message = "InvalidDistribution: Cannot find file (or expand pattern): 'missing.whl'"
+    assert dunder_main.main() == message

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 import sys
 from typing import Any
 
@@ -21,24 +20,18 @@ import requests
 
 from twine import cli
 from twine import exceptions
-from twine import settings
 
 
 def main() -> Any:
     try:
         return cli.dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.HTTPError) as exc:
-        parser = argparse.ArgumentParser()
-        settings.Settings.register_argparse_arguments(parser)
-        args, _ = parser.parse_known_args(sys.argv[1:])
-        color = not settings.Settings.from_argparse(args).no_color
-
-        return _format_error(f"{exc.__class__.__name__}: {exc.args[0]}", color=color)
+        return _format_error(f"{exc.__class__.__name__}: {exc.args[0]}")
 
 
-def _format_error(message: str, color: bool = True) -> str:
+def _format_error(message: str) -> str:
     pre_style, post_style = "", ""
-    if color:
+    if not cli.args.no_color:
         colorama.init()
         pre_style, post_style = colorama.Fore.RED, colorama.Style.RESET_ALL
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -27,6 +27,8 @@ import tqdm
 import twine
 from twine import _installed
 
+args = argparse.Namespace()
+
 
 def _registered_commands(
     group: str = "twine.registered_commands",
@@ -60,13 +62,20 @@ def dispatch(argv: List[str]) -> Any:
         version="%(prog)s version {} ({})".format(twine.__version__, dep_versions()),
     )
     parser.add_argument(
+        "--no-color",
+        default=False,
+        required=False,
+        action="store_true",
+        help="disable colored output",
+    )
+    parser.add_argument(
         "command", choices=registered_commands.keys(),
     )
     parser.add_argument(
         "args", help=argparse.SUPPRESS, nargs=argparse.REMAINDER,
     )
 
-    args = parser.parse_args(argv)
+    parser.parse_args(argv, namespace=args)
 
     main = registered_commands[args.command].load()
 

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -27,7 +27,6 @@ import readme_renderer.rst
 
 from twine import commands
 from twine import package as package_file
-from twine import settings
 
 _RENDERERS = {
     None: readme_renderer.rst,  # Default if description_content_type is None
@@ -106,11 +105,7 @@ def _check_file(
     return warnings, is_ok
 
 
-def check(
-    dists: List[str],
-    output_stream: IO[str] = sys.stdout,
-    check_settings: Optional[settings.Settings] = None,
-) -> bool:
+def check(dists: List[str], output_stream: IO[str] = sys.stdout) -> bool:
     uploads = [i for i in commands._find_dists(dists) if not i.endswith(".asc")]
     if not uploads:  # Return early, if there are no files to check.
         output_stream.write("No files to check.\n")
@@ -148,7 +143,6 @@ def check(
 
 def main(args: List[str]) -> bool:
     parser = argparse.ArgumentParser(prog="twine check")
-    settings.Settings.register_argparse_arguments(parser)
     parser.add_argument(
         "dists",
         nargs="+",
@@ -157,7 +151,6 @@ def main(args: List[str]) -> bool:
     )
 
     parsed_args = parser.parse_args(args)
-    check_settings = settings.Settings.from_argparse(parsed_args)
 
     # Call the check function with the arguments from the command line
-    return check(parsed_args.dists, check_settings=check_settings)
+    return check(parsed_args.dists)

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -59,7 +59,6 @@ class Settings:
         repository_url: Optional[str] = None,
         verbose: bool = False,
         disable_progress_bar: bool = False,
-        no_color: bool = False,
         **ignored_kwargs: Any,
     ) -> None:
         """Initialize our settings instance.
@@ -123,7 +122,6 @@ class Settings:
         self.comment = comment
         self.verbose = verbose
         self.disable_progress_bar = disable_progress_bar
-        self.no_color = no_color
         self.skip_existing = skip_existing
         self._handle_repository_options(
             repository_name=repository_name, repository_url=repository_url,
@@ -264,13 +262,6 @@ class Settings:
             required=False,
             action="store_true",
             help="Disable the progress bar.",
-        )
-        parser.add_argument(
-            "--no-color",
-            default=False,
-            required=False,
-            action="store_true",
-            help="Disable colored output.",
         )
 
     @classmethod


### PR DESCRIPTION
For https://github.com/pypa/twine/pull/649

Changes:

- Move `--no-color` option to base command parser
- Add `cli.args` to share base command options across modules
- Raise a real exception in `test_main.py`
- Revert changes to `check.py` and `test_check.py`

<img width="575" alt="Screen Shot 2020-06-17 at 6 10 18 AM" src="https://user-images.githubusercontent.com/1326704/84885933-b4cef600-b061-11ea-949f-11ed104fda68.png">
